### PR TITLE
Improved portability + extra fixes

### DIFF
--- a/assets/components/themebootstrap/elements/chunks/breadcrumb.row.tpl
+++ b/assets/components/themebootstrap/elements/chunks/breadcrumb.row.tpl
@@ -1,1 +1,1 @@
-<li><a href="[[+link]]">[[+pagetitle]]</a> <span class="divider">/</span></li>
+<li><a href="[[+link]]">[[+menutitle:default=[[+pagetitle]]`]]</a><span class="divider">/</span></li>

--- a/assets/components/themebootstrap/elements/chunks/breadcrumb.tpl
+++ b/assets/components/themebootstrap/elements/chunks/breadcrumb.tpl
@@ -1,5 +1,5 @@
-[[Breadcrumb?
-  &containerTpl=`tpl.Breadcrumb.container`
-  &linkCrumbTpl=`tpl.Breadcrumb.row`
-  &showHomeCrumb=`1`
+[[BreadCrumb?
+&containerTpl=`tpl.Breadcrumb.container`
+&linkCrumbTpl=`tpl.Breadcrumb.row`
+&showHomeCrumb=`1`
 ]]

--- a/assets/components/themebootstrap/elements/chunks/content.list.tpl
+++ b/assets/components/themebootstrap/elements/chunks/content.list.tpl
@@ -1,18 +1,17 @@
 <div id="content" class="main">
-	[[*id:gt=`1`:then=`<h1>[[*pagetitle]]</h1>`]]
-	[[*content]]
-	[[!getPage?
-		&parents=`[[*id]]`
-		&element=`getResources`
-		&tpl=`tpl.getResources.row`
-		&limit=`1`
-		&pageActiveTpl=`<li[[+activeClasses:default=` class="active"`]]><a[[+activeClasses:default=` class="active"`]][[+title]] href="[[+href]]">[[+pageNo]]</a></li>`
-	]]
+  [[*id:isnot=`[[++site_start]]`:then=`<h1>[[*longtitle:default=`[[*pagetitle]]`]]</h1>`]]
+  [[*content]]
+  [[!getPage?
+    &parents=`[[*id]]`
+    &element=`getResources`
+    &tpl=`tpl.getResources.row`
+    &limit=`1`
+    &pageActiveTpl=`<li[[+activeClasses:default=` class="active"`]]><a[[+activeClasses:default=` class="active"`]][[+title]] href="[[+href]]">[[+pageNo]]</a></li>`
+  ]]
 
-	<div class="pagination">
-		<ul>
-			[[!+page.nav]]
-		</ul>
-	</div>
-
+  <div class="pagination">
+    <ul>
+      [[!+page.nav]]
+    </ul>
+  </div>
 </div>

--- a/assets/components/themebootstrap/elements/chunks/content.tpl
+++ b/assets/components/themebootstrap/elements/chunks/content.tpl
@@ -1,4 +1,5 @@
 <div id="content" class="main">
-	[[*id:gt=`1`:then=`<h1>[[*pagetitle]]</h1>`]]
-	<p>[[*content]]</p>
+  [[*id:isnot=`[[++site_start]]`:then=`<h1>[[*longtitle:default=`[[*pagetitle]]`]]</h1>`]]
+  [[- <!-- I don't think the content needs an extra container, but if you really want one, use a <div> --> ]]
+  [[*content]]
 </div>

--- a/assets/components/themebootstrap/elements/chunks/counters.tpl
+++ b/assets/components/themebootstrap/elements/chunks/counters.tpl
@@ -1,2 +1,2 @@
-<!-- Javascript code for counting page hits -->
-<!-- For example - Google analitics -->
+<!-- JavaScript code for counting page hits -->
+<!-- For example: Google Analytics -->

--- a/assets/components/themebootstrap/elements/chunks/footer.tpl
+++ b/assets/components/themebootstrap/elements/chunks/footer.tpl
@@ -1,12 +1,11 @@
 <footer>
-	<div class="row">
-		<div class="span6">
-			<p>&copy;2012 [[++site_name]]</p>
-			<p><small>render time: [^t^]</small></p>
-			[[$Counters]]
-		</div>
-		<div class="span6">
-			<a href="http://bezumkin.ru" class="pull-right">Василий Наумкин</a>
-		</div>
-	</div>
+  <div class="row">
+    <div class="span6">
+      <p>&copy;2012 [[++site_name]]</p>
+      <p><small>render time: [^t^]</small></p>
+    </div>
+    <div class="span6">
+      <a href="http://bezumkin.ru" class="pull-right">Василий Наумкин</a>
+    </div>
+  </div>
 </footer>

--- a/assets/components/themebootstrap/elements/chunks/getresources.row.tpl
+++ b/assets/components/themebootstrap/elements/chunks/getresources.row.tpl
@@ -1,5 +1,5 @@
 <div>
-	<h3><a href="[[~[[+id]]]]">[[+pagetitle]]</a></h3>
-	<p>[[+introtext]]</p>
-	<p>[[+publishedon:strtotime:date=`%d.%m.%Y`]]</p>
+  <h3><a href="[[~[[+id]]]]">[[+longtitle:default=[[+pagetitle]]`]]</a></h3>
+  [[+introtext:notempty=`<p>[[+introtext]]</p>`]]
+  <p>[[+publishedon:strtotime:date=`%d.%m.%Y`]]</p>
 </div>

--- a/assets/components/themebootstrap/elements/chunks/head.tpl
+++ b/assets/components/themebootstrap/elements/chunks/head.tpl
@@ -1,9 +1,11 @@
 <base href="[[++site_url]]" />
-<title>[[*pagetitle]] - [[++site_name]]</title>
+<title>[[*longtitle:default=`[[*pagetitle]]`]] - [[++site_name]]</title>
+
+<meta charset="[[++modx_charset]]" />
 
 <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.7.2/jquery.min.js" type="text/javascript"></script>
-<script src="/assets/components/themebootstrap/js/bootstrap.min.js" type="text/javascript"></script>
-<script src="/assets/components/themebootstrap/js/main.js" type="text/javascript"></script>
-<link href="/assets/components/themebootstrap/css/bootstrap.min.css" rel="stylesheet">
-<link href="/assets/components/themebootstrap/css/main.css" rel="stylesheet">
-<link href="/assets/components/themebootstrap/css/bootstrap-responsive.min.css" rel="stylesheet">
+<script src="[[++assets_url]]components/themebootstrap/js/bootstrap.min.js" type="text/javascript"></script>
+<script src="[[++assets_url]]components/themebootstrap/js/main.js" type="text/javascript"></script>
+<link href="[[++assets_url]]components/themebootstrap/css/bootstrap.min.css" type="text/css" rel="stylesheet">
+<link href="[[++assets_url]]components/themebootstrap/css/main.css" type="text/css" rel="stylesheet">
+<link href="[[++assets_url]]components/themebootstrap/css/bootstrap-responsive.min.css" type="text/css" rel="stylesheet">

--- a/assets/components/themebootstrap/elements/chunks/navbar.tpl
+++ b/assets/components/themebootstrap/elements/chunks/navbar.tpl
@@ -1,23 +1,22 @@
 <div class="navbar navbar-fixed-top">
-    <div class="navbar-inner">
-        <div class="container">
-            <a class="btn btn-navbar" data-toggle="collapse" data-target=".nav-collapse">
-	            <span class="icon-bar"></span>
-	            <span class="icon-bar"></span>
-	            <span class="icon-bar"></span>
-            </a>
-            <a class="brand" href="/">[[++site_name]]</a>
-            <div class="nav-collapse">
-	            [[Wayfinder?
-	                &outerClass=`nav`
-	                &innerClass=`dropdown-menu`
-	                &rowTpl=`tpl.Wayfinder.row`
-	                &innerRowTpl=`tpl.Wayfinder.row.inner`
-	                &startId=`0`
-	                &level=`2`
-	                &titleOfLinks=``
-	            ]]
-			</div>
-        </div>
+  <div class="navbar-inner">
+    <div class="container">
+      <a class="btn btn-navbar" data-toggle="collapse" data-target=".nav-collapse">
+        <span class="icon-bar"></span>
+        <span class="icon-bar"></span>
+        <span class="icon-bar"></span>
+      </a>
+      <a class="brand" href="[[~[[++site_start]]]]">[[++site_name]]</a>
+      <div class="nav-collapse">
+        [[Wayfinder?
+        &outerClass=`nav`
+        &innerClass=`dropdown-menu`
+        &rowTpl=`tpl.Wayfinder.row`
+        &innerRowTpl=`tpl.Wayfinder.row.inner`
+        &startId=`0`
+        &level=`2`
+        ]]
+      </div>
     </div>
+  </div>
 </div>

--- a/assets/components/themebootstrap/elements/chunks/wayfinder.row.inner.tpl
+++ b/assets/components/themebootstrap/elements/chunks/wayfinder.row.inner.tpl
@@ -1,4 +1,4 @@
-<li class="[[+wf.classnames]]">
-	<a href="[[+wf.link]]" title="[[+wf.title]]" [[+wf.attributes]]>[[+wf.linktext]]</a>
-	[[+wf.wrapper]]
+<li[[+wf.classnames:notempty=` class="[[+wf.classnames]]"`]]>
+  <a href="[[+wf.link]]" title="[[+wf.title]]" [[+wf.attributes]]>[[+wf.linktext]]</a>
+  [[+wf.wrapper]]
 </li>

--- a/assets/components/themebootstrap/elements/chunks/wayfinder.row.tpl
+++ b/assets/components/themebootstrap/elements/chunks/wayfinder.row.tpl
@@ -1,4 +1,4 @@
-<li class="[[+wf.classnames]] [[+wf.isfolder:is=`1`:then=`dropdown`]]">
-	<a href="[[+wf.link]]" title="[[+wf.title]]" [[+wf.isfolder:is=`1`:then=`class="dropdown-toggle" data-toggle="dropdown"`]] [[+wf.attributes]]>[[+wf.linktext]] [[+wf.isfolder:is=`1`:then=`<b class="caret"></b>`]]</a>
-	[[+wf.wrapper]]
+<li class="[[+wf.classnames]][[+wf.isfolder:is=`1`:then=` dropdown`]]">
+  <a href="[[+wf.link]]" title="[[+wf.title]]"[[+wf.isfolder:is=`1`:then=` class="dropdown-toggle" data-toggle="dropdown"`]] [[+wf.attributes]]>[[+wf.linktext]][[+wf.isfolder:is=`1`:then=` <b class="caret"></b>`]]</a>
+  [[+wf.wrapper]]
 </li>

--- a/assets/components/themebootstrap/elements/templates/bootstrap.tpl
+++ b/assets/components/themebootstrap/elements/templates/bootstrap.tpl
@@ -1,14 +1,15 @@
 <!DOCTYPE html>
-<html>
+<html lang="[[++cultureKey]]">
   <head>
     [[$Head]]
   </head>
   <body>
     [[$Navbar]]
     <div class="container">
-      [[*id:gt=`1`:then=`[[$Breadcrumb]]`]]
+      [[*id:isnot=`[[++site_start]]`:then=`[[$Breadcrumb]]`]]
       [[$Content]]
       [[$Footer]]
     </div>
+    [[$Counters]]
   </body>
 </html>


### PR DESCRIPTION
- Replaced a lot of absolute values with MODX variables, making the whole theme a lot more portable (i.e. /assets/ to [[++assets_url]] ) 
- Replaced a number of pagetitle variables with longtitle and menutitle variables, all of them defaulting to pagetitle 
- Only display the introtext if there is any 
- Adjusted the html tag and inserted a meta tag in order to declare the language used in the page 
- Removed the empty titleOfLinks parameter in the Wayfinder Snippet call in the Navbar Chunk since it caused an error 
- Changed the BreadCrumb snippet call in the Breadcrumb Chunk from Breadcrumb to BreadCrumb, so it actually works
